### PR TITLE
[SR-5457] Diagnose lexing of an executable file

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -98,6 +98,8 @@ ERROR(lex_utf16_bom_marker,none,
 
 ERROR(lex_hashbang_not_allowed,none,
       "hashbang line is allowed only in the main file", ())
+ERROR(lex_start_of_executable,none,
+      "start of executable detected when expecting source file; did you mean to use call executable directly?", ())
 
 ERROR(lex_unprintable_ascii_character,none,
       "unprintable ASCII character found in source file", ())

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -469,6 +469,9 @@ public:
   };
 
 private:
+    
+  bool checkForStartOfExecutable();
+
   /// For a source location in the current buffer, returns the corresponding
   /// pointer.
   const char *getBufferPtrForSourceLoc(SourceLoc Loc) const {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds ability for the Lexer to detect the case when the input file is an executable. Outputs a friendly error diagnostic instead of "error: invalid UTF-8 found in source file". 

Based on the description in SR-5457, this could be a common mistake for developers with a scripting background, or those who initially learn to use swift to compile and run a single source file.

Note: This is a WIP
- [ ] how to write a unit test for this case
- [ ] decide on better wording for the diagnostic message

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5457](https://bugs.swift.org/browse/SR-5457).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->